### PR TITLE
HasManyOfDescendants should register global scopes on descendants

### DIFF
--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -13,6 +13,21 @@ use Staudenmeir\LaravelAdjacencyList\Query\Grammars\SqlServerGrammar;
 class Builder extends Base
 {
     /**
+     * Register all passed global scopes.
+     *
+     * @param  array|null  $scopes
+     * @return $this
+     */
+    public function withGlobalScopes(array $scopes)
+	{
+		foreach ($scopes as $identifier => $scope) {
+			$this->withGlobalScope($identifier, $scope);
+		}
+
+        return $this;
+	}
+
+    /**
      * Get the hydrated models without eager loading.
      *
      * @param array $columns

--- a/src/Eloquent/Relations/HasManyOfDescendants.php
+++ b/src/Eloquent/Relations/HasManyOfDescendants.php
@@ -7,10 +7,13 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Str;
+use Staudenmeir\LaravelAdjacencyList\Eloquent\TracksIntermediateScopes;
 use Staudenmeir\LaravelAdjacencyList\Query\Grammars\ExpressionGrammar;
 
 class HasManyOfDescendants extends HasMany
 {
+    use TracksIntermediateScopes;
+
     /**
      * Whether to include the parent model.
      *
@@ -216,7 +219,11 @@ class HasManyOfDescendants extends HasMany
         $query->withGlobalScope('HasManyOfDescendants', function (Builder $query) use ($name) {
             $query->whereIn(
                 $this->foreignKey,
-                (new $this->parent)->setTable($name)->newQuery()->select($this->localKey)
+                (new $this->parent)->setTable($name)
+                    ->newQuery()
+                    ->select($this->localKey)
+                    ->withGlobalScopes($this->intermediateScopes)
+                    ->withoutGlobalScopes($this->removedIntermediateScopes)
             );
         });
 

--- a/src/Eloquent/TracksIntermediateScopes.php
+++ b/src/Eloquent/TracksIntermediateScopes.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Staudenmeir\LaravelAdjacencyList\Eloquent;
+
+trait TracksIntermediateScopes
+{
+	/**
+	 * Applied intermediate Scopes.
+	 *
+	 * @var array
+	 */
+	protected $intermediateScopes = [];
+
+	/**
+	 * Removed intermediate Scopes.
+	 *
+	 * @var array
+	 */
+	protected $removedIntermediateScopes = [];
+
+	/**
+	 * Register a new intermediate scope.
+	 *
+	 * @param  string  $identifier
+	 * @param  \Illuminate\Database\Eloquent\Scope|\Closure  $scope
+	 * @return $this
+	 */
+	public function withIntermediateScope($identifier, $scope)
+	{
+		$this->intermediateScopes[$identifier] = $scope;
+
+		if (method_exists($scope, 'extend')) {
+			$scope->extend($this);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Remove a registered intermediate scope.
+	 *
+	 * @param  \Illuminate\Database\Eloquent\Scope|string  $scope
+	 * @return $this
+	 */
+	public function withoutIntermediateScope($scope)
+	{
+		if (!is_string($scope)) {
+			$scope = get_class($scope);
+		}
+
+		unset($this->intermediateScopes[$scope]);
+
+		$this->removedIntermediateScopes[] = $scope;
+
+		return $this;
+	}
+
+	/**
+	 * Remove all or passed registered intermediate Scopes.
+	 *
+	 * @param  array|null  $scopes
+	 * @return $this
+	 */
+	public function withoutIntermediateScopes(array $scopes = null)
+	{
+		if (!is_array($scopes)) {
+			$scopes = array_keys($this->intermediateScopes);
+		}
+
+		foreach ($scopes as $scope) {
+			$this->withoutIntermediateScope($scope);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Get an array of intermediate Scopes that were removed from the query.
+	 *
+	 * @return array
+	 */
+	public function removedIntermediateScopes()
+	{
+		return $this->removedIntermediateScopes;
+	}
+}


### PR DESCRIPTION
Suppose the following scenario:

```
class Organisation
{
    use HasRecursiveRelationships;

    protected static function booted()
    {
        static::addGlobalScope('non-bankrupt', function (Builder $builder) {
            $builder->where('bankrupt', false);
        });
    }

    public function employees()
    {
        return $this->hasMany(Employee::class);
    }

    public function employeesOfDescendantsAndSelf()
    {
        return $this->hasManyOfDescendantsAndSelf(Employee::class);
    }
}
```

Then calling
`$organisation->descendants()->withoutGlobalScope('non-bankrupt')->get()`
works just fine. However, calling
`$organisation->employeesOfDescendantsAndSelf()->withoutGlobalScope('non-bankrupt')->get()`
does not work, as the global scope 'non-bankrupt' is removed from the `Employee` model and not from the `Organisation` model. 

This PR suggest adding the methods `withIntermediateScope`, `withoutIntermediateScope` and `withoutIntermediateScopes`, using which 
`$organisation->employeesOfDescendantsAndSelf()->withoutIntermediateScope('non-bankrupt')->get()`
works as intended. (I haven't tested `withIntermediateScope` yet.) Is this something you'd consider adding to the package? 