### PR TITLE
fix: hasManyOfDescendants causes error "Undefined array key 0" 

### DIFF
--- a/src/Eloquent/Relations/Traits/IsOfDescendantsRelation.php
+++ b/src/Eloquent/Relations/Traits/IsOfDescendantsRelation.php
@@ -108,6 +108,10 @@ trait IsOfDescendantsRelation
     {
         $dictionary = [];
 
+        if ($results->isEmpty()) {
+            return $dictionary;
+        }
+
         $paths = explode(
             $this->getPathListSeparator(),
             $results[0]->{$this->pathListAlias}


### PR DESCRIPTION
This occurs when no results are found using the `->with('item.items')` dot notation. In which the `items` is a `hasManyOfDescendants` relationship.

May be related to: https://github.com/staudenmeir/laravel-adjacency-list/issues/161