### PR TITLE
Directly provide a model to treeOf

### DIFF
--- a/src/Eloquent/Traits/HasRecursiveRelationshipScopes.php
+++ b/src/Eloquent/Traits/HasRecursiveRelationshipScopes.php
@@ -3,6 +3,7 @@
 namespace Staudenmeir\LaravelAdjacencyList\Eloquent\Traits;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Query\JoinClause;
 use Staudenmeir\LaravelAdjacencyList\Query\Grammars\ExpressionGrammar;
 
@@ -28,12 +29,18 @@ trait HasRecursiveRelationshipScopes
      * Add a recursive expression for a custom tree to the query.
      *
      * @param \Illuminate\Database\Eloquent\Builder $query
-     * @param callable $constraint
+     * @param callable|\Illuminate\Database|Eloquent\Model $constraint
      * @param int|null $maxDepth
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function scopeTreeOf(Builder $query, callable $constraint, $maxDepth = null)
+    public function scopeTreeOf(Builder $query, callable|Model $constraint, $maxDepth = null)
     {
+        if ($constraint instanceof Model) {
+            $constraint = function($query) use ($constraint) {
+                $query->whereKey($constraint->getKey());
+            };
+        }
+        
         return $query->withRelationshipExpression('desc', $constraint, 0, null, $maxDepth);
     }
 

--- a/tests/Tree/EloquentTest.php
+++ b/tests/Tree/EloquentTest.php
@@ -88,18 +88,18 @@ class EloquentTest extends TestCase
     
     public function testScopeTreeOfWithModel()
     {
-        $constraint = User::find(2);
+        $model = User::find(2);
 
-        $tree = User::treeOf($constraint)->orderBy('id')->get();
+        $tree = User::treeOf($model)->orderBy('id')->get();
 
         $this->assertEquals([2, 5, 8], $tree->pluck('id')->all());
     }
 
     public function testScopeTreeOfWithModelAndMaxDepth()
     {
-        $constraint = User::find(2);
+        $model = User::find(2);
 
-        $tree = User::treeOf($constraint, 1)->orderBy('id')->get();
+        $tree = User::treeOf($model, 1)->orderBy('id')->get();
 
         $this->assertEquals([2, 5], $tree->pluck('id')->all());
     }

--- a/tests/Tree/EloquentTest.php
+++ b/tests/Tree/EloquentTest.php
@@ -64,7 +64,7 @@ class EloquentTest extends TestCase
         $this->assertEquals([1, 2, 3, 4, 5, 6, 7, 11, 12], $tree->pluck('id')->all());
     }
 
-    public function testScopeTreeOf()
+    public function testScopeTreeOfWithCallable()
     {
         $constraint = function (Builder $query) {
             $query->whereIn('id', [2, 4]);
@@ -75,7 +75,7 @@ class EloquentTest extends TestCase
         $this->assertEquals([2, 4, 5, 7, 8], $tree->pluck('id')->all());
     }
 
-    public function testScopeTreeOfWithMaxDepth()
+    public function testScopeTreeOfWithCallableAndMaxDepth()
     {
         $constraint = function (Builder $query) {
             $query->whereIn('id', [2, 4]);
@@ -84,6 +84,24 @@ class EloquentTest extends TestCase
         $tree = User::treeOf($constraint, 1)->orderBy('id')->get();
 
         $this->assertEquals([2, 4, 5, 7], $tree->pluck('id')->all());
+    }
+    
+    public function testScopeTreeOfWithModel()
+    {
+        $constraint = User::find(2);
+
+        $tree = User::treeOf($constraint)->orderBy('id')->get();
+
+        $this->assertEquals([2, 5, 8], $tree->pluck('id')->all());
+    }
+
+    public function testScopeTreeOfWithModelAndMaxDepth()
+    {
+        $constraint = User::find(2);
+
+        $tree = User::treeOf($constraint, 1)->orderBy('id')->get();
+
+        $this->assertEquals([2, 5], $tree->pluck('id')->all());
     }
 
     public function testScopeHasChildren()


### PR DESCRIPTION
This PR enhances the `treeOf` scope to accept a model instance directly for improved readability.

Instead of
```php
User::treeOf(function($query) use ($user) {
    $query->whereKey($user->getKey());
})->get();
```

we can now do
```php
User::treeOf($user)->get();
```

Particularly useful to show the subtree of any model, regardless where it's located within the entire tree itself.