### PR TITLE
Add phpdoc for generics in Collection

### DIFF
--- a/src/Eloquent/Collection.php
+++ b/src/Eloquent/Collection.php
@@ -4,6 +4,12 @@ namespace Staudenmeir\LaravelAdjacencyList\Eloquent;
 
 use Illuminate\Database\Eloquent\Collection as Base;
 
+/**
+ * @template TKey of array-key
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ *
+ * @extends \Illuminate\Database\Eloquent\Collection<TKey, TModel>
+ */
 class Collection extends Base
 {
     public function toTree($childrenRelation = 'children')


### PR DESCRIPTION
Maybe there is another solution for this, but for me it looks like PHPStan is getting mad about using `map()` on the `Collection` from this package with specific model types in the callback functions:

```php
$categoryIds = Category::all()->map(fn (Category $cat) => $cat->id);
```
```
Parameter #1 $callback of method Illuminate\Database\Eloquent\Collection<(int|string),Illuminate\Database\Eloquent\Model>::map() expects callable(Illuminate\Database\Eloquent\Model, (int|string)): int, Closure(App\Models\Category): int given.
```

After some investigation, it appears that the generic types used by `Collection` are not preserved when a class is extended, so I've added them here.