### PR TITLE
Improvement: Add precision and scale for decimal column types in pivot

### DIFF
--- a/src/Eloquent/Traits/HasGraphRelationshipScopes.php
+++ b/src/Eloquent/Traits/HasGraphRelationshipScopes.php
@@ -201,9 +201,13 @@ trait HasGraphRelationshipScopes
                     $type = $query->getConnection()->getSchemaBuilder()->getColumnType($pivotTable, $column);
                 }
 
-                $precision = $query->getConnection()->getDoctrineColumn($pivotTable, $column)->getPrecision();
-                $scale = $query->getConnection()->getDoctrineColumn($pivotTable, $column)->getScale();
-                $null = $grammar->compilePivotColumnNullValue($type, $precision, $scale);
+                $doctrineColumn = $query->getConnection()->getDoctrineColumn($pivotTable, $column);
+
+                $null = $grammar->compilePivotColumnNullValue(
+                    $type,
+                    $doctrineColumn->getPrecision(),
+                    $doctrineColumn->getScale()
+                );
 
                 $query->selectRaw("$null as " . $grammar->wrap("pivot_$column"));
             }

--- a/src/Eloquent/Traits/HasGraphRelationshipScopes.php
+++ b/src/Eloquent/Traits/HasGraphRelationshipScopes.php
@@ -201,7 +201,9 @@ trait HasGraphRelationshipScopes
                     $type = $query->getConnection()->getSchemaBuilder()->getColumnType($pivotTable, $column);
                 }
 
-                $null = $grammar->compilePivotColumnNullValue($type);
+                $precision = $query->getConnection()->getDoctrineColumn($pivotTable, $column)->getPrecision();
+                $scale = $query->getConnection()->getDoctrineColumn($pivotTable, $column)->getScale();
+                $null = $grammar->compilePivotColumnNullValue($type, $precision, $scale);
 
                 $query->selectRaw("$null as " . $grammar->wrap("pivot_$column"));
             }

--- a/src/Query/Grammars/ExpressionGrammar.php
+++ b/src/Query/Grammars/ExpressionGrammar.php
@@ -56,9 +56,11 @@ interface ExpressionGrammar
      * Compile a pivot column null value.
      *
      * @param string $type
+     * @param int $precision
+     * @param int $scale
      * @return string
      */
-    public function compilePivotColumnNullValue(string $type): string;
+    public function compilePivotColumnNullValue(string $type, int $precision, int $scale): string;
 
     /**
      * Compile a cycle detection clause.

--- a/src/Query/Grammars/MySqlGrammar.php
+++ b/src/Query/Grammars/MySqlGrammar.php
@@ -101,12 +101,15 @@ SQL;
      * Compile a pivot column null value.
      *
      * @param string $type
+     * @param int $precision
+     * @param int $scale
      * @return string
      */
-    public function compilePivotColumnNullValue(string $type): string
+    public function compilePivotColumnNullValue(string $type, int $precision, int $scale): string
     {
         $cast = match ($type) {
             'bigint', 'boolean', 'integer', 'smallint' => 'signed',
+            'decimal' => "decimal($precision, $scale)",
             'string' => 'char(65535)',
             default => $type,
         };

--- a/src/Query/Grammars/PostgresGrammar.php
+++ b/src/Query/Grammars/PostgresGrammar.php
@@ -78,9 +78,11 @@ class PostgresGrammar extends Base implements ExpressionGrammar
      * Compile a pivot column null value.
      *
      * @param string $type
+     * @param int $precision
+     * @param int $scale
      * @return string
      */
-    public function compilePivotColumnNullValue(string $type): string
+    public function compilePivotColumnNullValue(string $type, int $precision, int $scale): string
     {
         $cast = match ($type) {
             'datetime' => 'timestamp',

--- a/src/Query/Grammars/SQLiteGrammar.php
+++ b/src/Query/Grammars/SQLiteGrammar.php
@@ -66,7 +66,7 @@ class SQLiteGrammar extends Base implements ExpressionGrammar
         )->from($expression);
     }
 
-        /**
+    /**
      * Compile a pivot column null value.
      *
      * @param string $type

--- a/src/Query/Grammars/SQLiteGrammar.php
+++ b/src/Query/Grammars/SQLiteGrammar.php
@@ -18,7 +18,7 @@ class SQLiteGrammar extends Base implements ExpressionGrammar
      */
     public function compileInitialPath($column, $alias)
     {
-        return 'cast('.$this->wrap($column).' as text) as '.$this->wrap($alias);
+        return 'cast(' . $this->wrap($column) . ' as text) as ' . $this->wrap($alias);
     }
 
     /**
@@ -61,18 +61,20 @@ class SQLiteGrammar extends Base implements ExpressionGrammar
     public function selectPathList(Builder $query, $expression, $column, $pathSeparator, $listSeparator)
     {
         return $query->selectRaw(
-            'group_concat('.$this->wrap($column).', ?)',
+            'group_concat(' . $this->wrap($column) . ', ?)',
             [$listSeparator]
         )->from($expression);
     }
 
-    /**
+        /**
      * Compile a pivot column null value.
      *
      * @param string $type
+     * @param int $precision
+     * @param int $scale
      * @return string
      */
-    public function compilePivotColumnNullValue(string $type): string
+    public function compilePivotColumnNullValue(string $type, int $precision, int $scale): string
     {
         return 'null';
     }

--- a/src/Query/Grammars/SqlServerGrammar.php
+++ b/src/Query/Grammars/SqlServerGrammar.php
@@ -75,9 +75,11 @@ class SqlServerGrammar extends Base implements ExpressionGrammar
      * Compile a pivot column null value.
      *
      * @param string $type
+     * @param int $precision
+     * @param int $scale
      * @return string
      */
-    public function compilePivotColumnNullValue(string $type): string
+    public function compilePivotColumnNullValue(string $type, int $precision, int $scale): string
     {
         throw new RuntimeException('This graph relationship feature is not supported on SQL Server.'); // @codeCoverageIgnore
     }

--- a/tests/Graph/AncestorsTest.php
+++ b/tests/Graph/AncestorsTest.php
@@ -26,7 +26,14 @@ class AncestorsTest extends TestCase
             $ancestors->pluck('reverse_slug_path')->all()
         );
         $this->assertEquals(
-            ['parent_id' => 1, 'child_id' => 5, 'label' => 'd', 'weight' => 4, 'created_at' => $this->getFormattedTestNow()],
+            [
+                'parent_id' => 1,
+                'child_id' => 5,
+                'label' => 'd',
+                'weight' => 4,
+                'value' => '123.456',
+                'created_at' => $this->getFormattedTestNow()
+            ],
             $ancestors[0]->pivot->getAttributes()
         );
     }
@@ -81,11 +88,25 @@ class AncestorsTest extends TestCase
             $ancestorsAndSelf->pluck('slug_path')->all()
         );
         $this->assertEquals(
-            ['parent_id' => null, 'child_id' => null, 'label' => null, 'weight' => null, 'created_at' => null],
+            [
+                'parent_id' => null,
+                'child_id' => null,
+                'label' => null,
+                'weight' => null,
+                'value' => null,
+                'created_at' => null
+            ],
             $ancestorsAndSelf[0]->pivot->getAttributes()
         );
         $this->assertEquals(
-            ['parent_id' => 1, 'child_id' => 5, 'label' => 'd', 'weight' => 4, 'created_at' => $this->getFormattedTestNow()],
+            [
+                'parent_id' => 1,
+                'child_id' => 5,
+                'label' => 'd',
+                'weight' => 4,
+                'value' => '123.456',
+                'created_at' => $this->getFormattedTestNow()
+            ],
             $ancestorsAndSelf[1]->pivot->getAttributes()
         );
     }
@@ -131,7 +152,14 @@ class AncestorsTest extends TestCase
         $this->assertEquals([-1, -1, -1, -2, -2], $nodes[4]->ancestors->pluck('depth')->all());
         $this->assertEquals(['1', '2', '10', '2.1', '2.9'], $nodes[4]->ancestors->pluck('path')->all());
         $this->assertEquals(
-            ['parent_id' => 1, 'child_id' => 5, 'label' => 'd', 'weight' => 4, 'created_at' => $this->getFormattedTestNow()],
+            [
+                'parent_id' => 1,
+                'child_id' => 5,
+                'label' => 'd',
+                'weight' => 4,
+                'value' => '123.456',
+                'created_at' => $this->getFormattedTestNow()
+            ],
             $nodes[4]->ancestors[0]->pivot->getAttributes()
         );
     }
@@ -187,11 +215,25 @@ class AncestorsTest extends TestCase
             $nodes[4]->ancestorsAndSelf->pluck('path')->all()
         );
         $this->assertEquals(
-            ['parent_id' => null, 'child_id' => null, 'label' => null, 'weight' => null, 'created_at' => null],
+            [
+                'parent_id' => null,
+                'child_id' => null,
+                'label' => null,
+                'weight' => null,
+                'value' => null,
+                'created_at' => null
+            ],
             $nodes[4]->ancestorsAndSelf[0]->pivot->getAttributes()
         );
         $this->assertEquals(
-            ['parent_id' => 1, 'child_id' => 5, 'label' => 'd', 'weight' => 4, 'created_at' => $this->getFormattedTestNow()],
+            [
+                'parent_id' => 1,
+                'child_id' => 5,
+                'label' => 'd',
+                'weight' => 4,
+                'value' => '123.456',
+                'created_at' => $this->getFormattedTestNow()
+            ],
             $nodes[4]->ancestorsAndSelf[1]->pivot->getAttributes()
         );
     }
@@ -237,7 +279,14 @@ class AncestorsTest extends TestCase
         $this->assertEquals([-1, -1, -1, -2, -2], $nodes[4]->ancestors->pluck('depth')->all());
         $this->assertEquals(['1', '2', '10', '2.1', '2.9'], $nodes[4]->ancestors->pluck('path')->all());
         $this->assertEquals(
-            ['parent_id' => 1, 'child_id' => 5, 'label' => 'd', 'weight' => 4, 'created_at' => $this->getFormattedTestNow()],
+            [
+                'parent_id' => 1,
+                'child_id' => 5,
+                'label' => 'd',
+                'weight' => 4,
+                'value' => '123.456',
+                'created_at' => $this->getFormattedTestNow()
+            ],
             $nodes[4]->ancestors[0]->pivot->getAttributes()
         );
     }
@@ -258,11 +307,25 @@ class AncestorsTest extends TestCase
             $nodes[4]->ancestorsAndSelf->pluck('path')->all()
         );
         $this->assertEquals(
-            ['parent_id' => null, 'child_id' => null, 'label' => null, 'weight' => null, 'created_at' => null],
+            [
+                'parent_id' => null,
+                'child_id' => null,
+                'label' => null,
+                'weight' => null,
+                'value' => null,
+                'created_at' => null
+            ],
             $nodes[4]->ancestorsAndSelf[0]->pivot->getAttributes()
         );
         $this->assertEquals(
-            ['parent_id' => 1, 'child_id' => 5, 'label' => 'd', 'weight' => 4, 'created_at' => $this->getFormattedTestNow()],
+            [
+                'parent_id' => 1,
+                'child_id' => 5,
+                'label' => 'd',
+                'weight' => 4,
+                'value' => '123.456',
+                'created_at' => $this->getFormattedTestNow()
+            ],
             $nodes[4]->ancestorsAndSelf[1]->pivot->getAttributes()
         );
     }

--- a/tests/Graph/DescendantsTest.php
+++ b/tests/Graph/DescendantsTest.php
@@ -26,7 +26,14 @@ class DescendantsTest extends TestCase
             $descendants->pluck('reverse_slug_path')->all()
         );
         $this->assertEquals(
-            ['parent_id' => 2, 'child_id' => 5, 'label' => 'e', 'weight' => 5, 'created_at' => $this->getFormattedTestNow()],
+            [
+                'parent_id' => 2,
+                'child_id' => 5,
+                'label' => 'e',
+                'weight' => 5,
+                'value' => '123.456',
+                'created_at' => $this->getFormattedTestNow()
+            ],
             $descendants[0]->pivot->getAttributes()
         );
     }
@@ -81,11 +88,25 @@ class DescendantsTest extends TestCase
             $descendantsAndSelf->pluck('slug_path')->all()
         );
         $this->assertEquals(
-            ['parent_id' => null, 'child_id' => null, 'label' => null, 'weight' => null, 'created_at' => null],
+            [
+                'parent_id' => null,
+                'child_id' => null,
+                'label' => null,
+                'weight' => null,
+                'value' => null,
+                'created_at' => null
+            ],
             $descendantsAndSelf[0]->pivot->getAttributes()
         );
         $this->assertEquals(
-            ['parent_id' => 2, 'child_id' => 5, 'label' => 'e', 'weight' => 5, 'created_at' => $this->getFormattedTestNow()],
+            [
+                'parent_id' => 2,
+                'child_id' => 5,
+                'label' => 'e',
+                'weight' => 5,
+                'value' => '123.456',
+                'created_at' => $this->getFormattedTestNow()
+            ],
             $descendantsAndSelf[1]->pivot->getAttributes()
         );
     }
@@ -139,7 +160,14 @@ class DescendantsTest extends TestCase
             $nodes[1]->descendants->pluck('path')->all()
         );
         $this->assertEquals(
-            ['parent_id' => 2, 'child_id' => 5, 'label' => 'e', 'weight' => 5, 'created_at' => $this->getFormattedTestNow()],
+            [
+                'parent_id' => 2,
+                'child_id' => 5,
+                'label' => 'e',
+                'weight' => 5,
+                'value' => '123.456',
+                'created_at' => $this->getFormattedTestNow()
+            ],
             $nodes[1]->descendants[0]->pivot->getAttributes()
         );
     }
@@ -203,11 +231,25 @@ class DescendantsTest extends TestCase
             $nodes[1]->descendantsAndSelf->pluck('path')->all()
         );
         $this->assertEquals(
-            ['parent_id' => null, 'child_id' => null, 'label' => null, 'weight' => null, 'created_at' => null],
+            [
+                'parent_id' => null,
+                'child_id' => null,
+                'label' => null,
+                'weight' => null,
+                'value' => null,
+                'created_at' => null
+            ],
             $nodes[1]->descendantsAndSelf[0]->pivot->getAttributes()
         );
         $this->assertEquals(
-            ['parent_id' => 2, 'child_id' => 5, 'label' => 'e', 'weight' => 5, 'created_at' => $this->getFormattedTestNow()],
+            [
+                'parent_id' => 2,
+                'child_id' => 5,
+                'label' => 'e',
+                'weight' => 5,
+                'value' => '123.456',
+                'created_at' => $this->getFormattedTestNow()
+            ],
             $nodes[1]->descendantsAndSelf[1]->pivot->getAttributes()
         );
     }
@@ -261,7 +303,14 @@ class DescendantsTest extends TestCase
             $nodes[1]->descendants->pluck('path')->all()
         );
         $this->assertEquals(
-            ['parent_id' => 2, 'child_id' => 5, 'label' => 'e', 'weight' => 5, 'created_at' => $this->getFormattedTestNow()],
+            [
+                'parent_id' => 2,
+                'child_id' => 5,
+                'label' => 'e',
+                'weight' => 5,
+                'value' => '123.456',
+                'created_at' => $this->getFormattedTestNow()
+            ],
             $nodes[1]->descendants[0]->pivot->getAttributes()
         );
     }
@@ -290,11 +339,25 @@ class DescendantsTest extends TestCase
             $nodes[1]->descendantsAndSelf->pluck('path')->all()
         );
         $this->assertEquals(
-            ['parent_id' => null, 'child_id' => null, 'label' => null, 'weight' => null, 'created_at' => null],
+            [
+                'parent_id' => null,
+                'child_id' => null,
+                'label' => null,
+                'weight' => null,
+                'value' => null,
+                'created_at' => null
+            ],
             $nodes[1]->descendantsAndSelf[0]->pivot->getAttributes()
         );
         $this->assertEquals(
-            ['parent_id' => 2, 'child_id' => 5, 'label' => 'e', 'weight' => 5, 'created_at' => $this->getFormattedTestNow()],
+            [
+                'parent_id' => 2,
+                'child_id' => 5,
+                'label' => 'e',
+                'weight' => 5,
+                'value' => '123.456',
+                'created_at' => $this->getFormattedTestNow()
+            ],
             $nodes[1]->descendantsAndSelf[1]->pivot->getAttributes()
         );
     }

--- a/tests/Graph/EloquentTest.php
+++ b/tests/Graph/EloquentTest.php
@@ -43,7 +43,14 @@ class EloquentTest extends TestCase
 
         $this->assertEquals([2, 3, 4, 5], $children->pluck('id')->all());
         $this->assertEquals(
-            ['parent_id' => 1, 'child_id' => 2, 'label' => 'a', 'weight' => 1, 'created_at' => $this->getFormattedTestNow()],
+            [
+                'parent_id' => 1,
+                'child_id' => 2,
+                'label' => 'a',
+                'weight' => 1,
+                'value' => '123.456',
+                'created_at' => $this->getFormattedTestNow()
+            ],
             $children[0]->pivot->getAttributes()
         );
     }
@@ -65,7 +72,14 @@ class EloquentTest extends TestCase
 
         $this->assertEquals([1, 2, 10], $parents->pluck('id')->all());
         $this->assertEquals(
-            ['parent_id' => 1, 'child_id' => 5, 'label' => 'd', 'weight' => 4, 'created_at' => $this->getFormattedTestNow()],
+            [
+                'parent_id' => 1,
+                'child_id' => 5,
+                'label' => 'd',
+                'weight' => 4,
+                'value' => '123.456',
+                'created_at' => $this->getFormattedTestNow()
+            ],
             $parents[0]->pivot->getAttributes()
         );
     }

--- a/tests/Graph/Models/Node.php
+++ b/tests/Graph/Models/Node.php
@@ -46,7 +46,7 @@ class Node extends Model
     {
         return array_merge(
             $this->baseGetPivotColumns(),
-            ['label', 'weight', 'created_at']
+            ['label', 'weight', 'value', 'created_at']
         );
     }
 }

--- a/tests/Graph/TestCase.php
+++ b/tests/Graph/TestCase.php
@@ -66,6 +66,7 @@ abstract class TestCase extends Base
                 $table->uuid('child_uuid');
                 $table->string('label');
                 $table->tinyInteger('weight');
+                $table->decimal('value', 8, 3);
                 $table->timestamp('created_at');
             }
         );
@@ -100,6 +101,7 @@ abstract class TestCase extends Base
                     'child_uuid' => 'b0f1b2c3-d4e5-4f6a-8b9b-0c1d2e3f4a5b',
                     'label' => 'a',
                     'weight' => 1,
+                    'value' => '123.456',
                     'created_at' => Carbon::now(),
                 ],
                 [
@@ -109,6 +111,7 @@ abstract class TestCase extends Base
                     'child_uuid' => 'c0f1b2c3-d4e5-4f6a-8b9b-0c1d2e3f4a5b',
                     'label' => 'b',
                     'weight' => 2,
+                    'value' => '123.456',
                     'created_at' => Carbon::now(),
                 ],
                 [
@@ -118,6 +121,7 @@ abstract class TestCase extends Base
                     'child_uuid' => 'd0f1b2c3-d4e5-4f6a-8b9b-0c1d2e3f4a5b',
                     'label' => 'c',
                     'weight' => 3,
+                    'value' => '123.456',
                     'created_at' => Carbon::now(),
                 ],
                 [
@@ -127,6 +131,7 @@ abstract class TestCase extends Base
                     'child_uuid' => 'e0f1b2c3-d4e5-4f6a-8b9b-0c1d2e3f4a5b',
                     'label' => 'd',
                     'weight' => 4,
+                    'value' => '123.456',
                     'created_at' => Carbon::now(),
                 ],
                 [
@@ -136,6 +141,7 @@ abstract class TestCase extends Base
                     'child_uuid' => 'e0f1b2c3-d4e5-4f6a-8b9b-0c1d2e3f4a5b',
                     'label' => 'e',
                     'weight' => 5,
+                    'value' => '123.456',
                     'created_at' => Carbon::now(),
                 ],
                 [
@@ -145,6 +151,7 @@ abstract class TestCase extends Base
                     'child_uuid' => 'f0f1b2c3-d4e5-4f6a-8b9b-0c1d2e3f4a5b',
                     'label' => 'f',
                     'weight' => 6,
+                    'value' => '123.456',
                     'created_at' => Carbon::now(),
                 ],
                 [
@@ -154,6 +161,7 @@ abstract class TestCase extends Base
                     'child_uuid' => 'a1f1b2c3-d4e5-4f6a-8b9b-0c1d2e3f4a5b',
                     'label' => 'g',
                     'weight' => 7,
+                    'value' => '123.456',
                     'created_at' => Carbon::now(),
                 ],
                 [
@@ -163,6 +171,7 @@ abstract class TestCase extends Base
                     'child_uuid' => 'b1f1b2c3-d4e5-4f6a-8b9b-0c1d2e3f4a5b',
                     'label' => 'h',
                     'weight' => 8,
+                    'value' => '123.456',
                     'created_at' => Carbon::now(),
                 ],
                 [
@@ -172,6 +181,7 @@ abstract class TestCase extends Base
                     'child_uuid' => 'b1f1b2c3-d4e5-4f6a-8b9b-0c1d2e3f4a5b',
                     'label' => 'i',
                     'weight' => 9,
+                    'value' => '123.456',
                     'created_at' => Carbon::now(),
                 ],
                 [
@@ -181,6 +191,7 @@ abstract class TestCase extends Base
                     'child_uuid' => 'b0f1b2c3-d4e5-4f6a-8b9b-0c1d2e3f4a5b',
                     'label' => 'j',
                     'weight' => 10,
+                    'value' => '123.456',
                     'created_at' => Carbon::now(),
                 ],
                 [
@@ -190,6 +201,7 @@ abstract class TestCase extends Base
                     'child_uuid' => 'e0f1b2c3-d4e5-4f6a-8b9b-0c1d2e3f4a5b',
                     'label' => 'k',
                     'weight' => 11,
+                    'value' => '123.456',
                     'created_at' => Carbon::now(),
                 ],
                 [
@@ -199,6 +211,7 @@ abstract class TestCase extends Base
                     'child_uuid' => 'e0f1b2c3-d4e5-4f6a-8b9b-0c1d2e3f4a5b',
                     'label' => 'l',
                     'weight' => 12,
+                    'value' => '123.456',
                     'created_at' => Carbon::now(),
                 ],
             ]
@@ -225,6 +238,7 @@ abstract class TestCase extends Base
                     'child_uuid' => 'a2f1b2c3-d4e5-4f6a-8b9b-0c1d2e3f4a5b',
                     'label' => 'm',
                     'weight' => 13,
+                    'value' => '123.456',
                     'created_at' => Carbon::now(),
                 ],
                 [
@@ -234,6 +248,7 @@ abstract class TestCase extends Base
                     'child_uuid' => 'b2f1b2c3-d4e5-4f6a-8b9b-0c1d2e3f4a5b',
                     'label' => 'n',
                     'weight' => 14,
+                    'value' => '123.456',
                     'created_at' => Carbon::now(),
                 ],
                 [
@@ -243,6 +258,7 @@ abstract class TestCase extends Base
                     'child_uuid' => 'f1f1b2c3-d4e5-4f6a-8b9b-0c1d2e3f4a5b',
                     'label' => 'o',
                     'weight' => 15,
+                    'value' => '123.456',
                     'created_at' => Carbon::now(),
                 ],
             ]


### PR DESCRIPTION
This PR enhances the `compilePivotColumnNullValue` method to add in customized `precision`  and `scale` for `decimal` column types.
By taking into account the set precision and scale values, we will be able to avoid potential SQL errors `Numeric value out of range.`

This will occur when we set a non-default value for decimal columns on the table in the user application.
`$table->decimal(column: 'inheritance', total: 15, places: 2)->default(0);`

This results in the inability to call `descendantsAndSelf` or `ancestorsAndSelf` if the value of `shares_allotted` on the pivot table exceeds the [default mysql precision and scale of (10,0).](https://dev.mysql.com/doc/refman/8.0/en/fixed-point-types.html#:~:text=The%20default%20value%20of%20M,scale%20for%20a%20given%20column.)

Attaching a screenshot of the sql statement generated by the package, using the default decimal casting :)
![Screenshot 2023-07-07 at 3 26 31 PM](https://github.com/staudenmeir/laravel-adjacency-list/assets/68610463/5bf60e4c-1c79-4bbd-ac95-bd631a989413)


