### PR TITLE
Add Relation generics

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "barryvdh/laravel-ide-helper": "^2.13",
         "mockery/mockery": "^1.5.1",
         "staudenmeir/eloquent-has-many-deep": "^1.18.1",
-        "phpstan/phpstan": "^1.10",
         "nunomaduro/larastan": "^2.0",
         "orchestra/testbench": "^8.15"
     },

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,9 @@
         "barryvdh/laravel-ide-helper": "^2.13",
         "mockery/mockery": "^1.5.1",
         "staudenmeir/eloquent-has-many-deep": "^1.18.1",
-        "phpstan/phpstan": "^1.10"
+        "phpstan/phpstan": "^1.10",
+        "nunomaduro/larastan": "^2.0",
+        "orchestra/testbench": "^8.15"
     },
     "suggest": {
         "barryvdh/laravel-ide-helper": "Provide type hints for attributes and relations."

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,3 +1,5 @@
+includes:
+    - ./vendor/nunomaduro/larastan/extension.neon
 parameters:
     level: 0
     paths:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,7 +1,7 @@
 includes:
     - ./vendor/nunomaduro/larastan/extension.neon
 parameters:
-    level: 0
+    level: 1
     paths:
         - src
         - tests

--- a/src/Eloquent/Collection.php
+++ b/src/Eloquent/Collection.php
@@ -12,6 +12,12 @@ use Illuminate\Database\Eloquent\Collection as Base;
  */
 class Collection extends Base
 {
+    /**
+     * Generate a nested tree.
+     *
+     * @param string $childrenRelation
+     * @return static<int, TModel>
+     */
     public function toTree($childrenRelation = 'children')
     {
         if ($this->isEmpty()) {

--- a/src/Eloquent/Relations/Ancestors.php
+++ b/src/Eloquent/Relations/Ancestors.php
@@ -7,6 +7,10 @@ use Staudenmeir\EloquentHasManyDeepContracts\Interfaces\ConcatenableRelation;
 use Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Traits\Concatenation\IsConcatenableAncestorsRelation;
 use Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Traits\IsAncestorRelation;
 
+/**
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @extends HasMany<TRelatedModel>
+ */
 class Ancestors extends HasMany implements ConcatenableRelation
 {
     use IsAncestorRelation;

--- a/src/Eloquent/Relations/BelongsToManyOfDescendants.php
+++ b/src/Eloquent/Relations/BelongsToManyOfDescendants.php
@@ -7,6 +7,10 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Traits\IsOfDescendantsRelation;
 
+/**
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @extends BelongsToMany<TRelatedModel>
+ */
 class BelongsToManyOfDescendants extends BelongsToMany
 {
     use IsOfDescendantsRelation {

--- a/src/Eloquent/Relations/Bloodline.php
+++ b/src/Eloquent/Relations/Bloodline.php
@@ -5,6 +5,10 @@ namespace Staudenmeir\LaravelAdjacencyList\Eloquent\Relations;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @extends Descendants<TRelatedModel>
+ */
 class Bloodline extends Descendants
 {
     /**

--- a/src/Eloquent/Relations/Descendants.php
+++ b/src/Eloquent/Relations/Descendants.php
@@ -11,6 +11,10 @@ use Staudenmeir\EloquentHasManyDeepContracts\Interfaces\ConcatenableRelation;
 use Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Traits\Concatenation\IsConcatenableDescendantsRelation;
 use Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Traits\IsRecursiveRelation;
 
+/**
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @extends HasMany<TRelatedModel>
+ */
 class Descendants extends HasMany implements ConcatenableRelation
 {
     use IsConcatenableDescendantsRelation;

--- a/src/Eloquent/Relations/Graph/Ancestors.php
+++ b/src/Eloquent/Relations/Graph/Ancestors.php
@@ -8,6 +8,10 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Query\Expression;
 use Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Graph\Traits\IsRecursiveRelation;
 
+/**
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @extends BelongsToMany<TRelatedModel>
+ */
 class Ancestors extends BelongsToMany
 {
     use IsRecursiveRelation {

--- a/src/Eloquent/Relations/Graph/Descendants.php
+++ b/src/Eloquent/Relations/Graph/Descendants.php
@@ -8,6 +8,10 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Query\Expression;
 use Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Graph\Traits\IsRecursiveRelation;
 
+/**
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @extends BelongsToMany<TRelatedModel>
+ */
 class Descendants extends BelongsToMany
 {
     use IsRecursiveRelation {

--- a/src/Eloquent/Relations/HasManyOfDescendants.php
+++ b/src/Eloquent/Relations/HasManyOfDescendants.php
@@ -7,6 +7,10 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Traits\IsOfDescendantsRelation;
 
+/**
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @extends HasMany<TRelatedModel>
+ */
 class HasManyOfDescendants extends HasMany
 {
     use IsOfDescendantsRelation;

--- a/src/Eloquent/Relations/MorphToManyOfDescendants.php
+++ b/src/Eloquent/Relations/MorphToManyOfDescendants.php
@@ -5,6 +5,10 @@ namespace Staudenmeir\LaravelAdjacencyList\Eloquent\Relations;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @extends BelongsToManyOfDescendants<TRelatedModel>
+ */
 class MorphToManyOfDescendants extends BelongsToManyOfDescendants
 {
     /**

--- a/src/Eloquent/Relations/RootAncestor.php
+++ b/src/Eloquent/Relations/RootAncestor.php
@@ -7,6 +7,10 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Traits\IsAncestorRelation;
 
+/**
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @extends HasOne<TRelatedModel>
+ */
 class RootAncestor extends HasOne
 {
     use IsAncestorRelation {

--- a/src/Eloquent/Relations/Siblings.php
+++ b/src/Eloquent/Relations/Siblings.php
@@ -7,6 +7,10 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
+/**
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @extends HasMany<TRelatedModel>
+ */
 class Siblings extends HasMany
 {
     /**
@@ -112,7 +116,7 @@ class Siblings extends HasMany
     /**
      * Get the results of the relationship.
      *
-     * @return mixed
+     * @phpstan-return \Traversable<int, TRelatedModel>
      */
     public function getResults()
     {

--- a/src/Eloquent/Traits/HasAdjacencyList.php
+++ b/src/Eloquent/Traits/HasAdjacencyList.php
@@ -117,7 +117,7 @@ trait HasAdjacencyList
     /**
      * Get the model's ancestors.
      *
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Ancestors
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Ancestors<static>
      */
     public function ancestors()
     {
@@ -133,7 +133,7 @@ trait HasAdjacencyList
     /**
      * Get the model's ancestors and itself.
      *
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Ancestors
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Ancestors<static>
      */
     public function ancestorsAndSelf()
     {
@@ -154,7 +154,7 @@ trait HasAdjacencyList
      * @param string $foreignKey
      * @param string $localKey
      * @param bool $andSelf
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Ancestors
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Ancestors<static>
      */
     protected function newAncestors(Builder $query, Model $parent, $foreignKey, $localKey, $andSelf)
     {
@@ -164,7 +164,7 @@ trait HasAdjacencyList
     /**
      * Get the model's bloodline.
      *
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Bloodline
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Bloodline<static>
      */
     public function bloodline()
     {
@@ -183,7 +183,7 @@ trait HasAdjacencyList
      * @param \Illuminate\Database\Eloquent\Model $parent
      * @param string $foreignKey
      * @param string $localKey
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Bloodline
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Bloodline<static>
      */
     protected function newBloodline(Builder $query, Model $parent, $foreignKey, $localKey)
     {
@@ -193,7 +193,7 @@ trait HasAdjacencyList
     /**
      * Get the model's children.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany<static>
      */
     public function children()
     {
@@ -203,7 +203,7 @@ trait HasAdjacencyList
     /**
      * Get the model's children and itself.
      *
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Descendants
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Descendants<static>
      */
     public function childrenAndSelf()
     {
@@ -213,7 +213,7 @@ trait HasAdjacencyList
     /**
      * Get the model's descendants.
      *
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Descendants
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Descendants<static>
      */
     public function descendants()
     {
@@ -229,7 +229,7 @@ trait HasAdjacencyList
     /**
      * Get the model's descendants and itself.
      *
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Descendants
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Descendants<static>
      */
     public function descendantsAndSelf()
     {
@@ -250,7 +250,7 @@ trait HasAdjacencyList
      * @param string $foreignKey
      * @param string $localKey
      * @param bool $andSelf
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Descendants
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Descendants<static>
      */
     protected function newDescendants(Builder $query, Model $parent, $foreignKey, $localKey, $andSelf)
     {
@@ -260,7 +260,7 @@ trait HasAdjacencyList
     /**
      * Get the model's parent.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<static, static>
      */
     public function parent()
     {
@@ -270,7 +270,7 @@ trait HasAdjacencyList
     /**
      * Get the model's parent and itself.
      *
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Ancestors
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Ancestors<static>
      */
     public function parentAndSelf()
     {
@@ -280,7 +280,7 @@ trait HasAdjacencyList
     /**
      * Get the model's root ancestor.
      *
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\RootAncestor
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\RootAncestor<static>
      */
     public function rootAncestor()
     {
@@ -299,7 +299,7 @@ trait HasAdjacencyList
      * @param \Illuminate\Database\Eloquent\Model $parent
      * @param string $foreignKey
      * @param string $localKey
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\RootAncestor
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\RootAncestor<static>
      */
     protected function newRootAncestor(Builder $query, Model $parent, $foreignKey, $localKey)
     {
@@ -309,7 +309,7 @@ trait HasAdjacencyList
     /**
      * Get the model's siblings.
      *
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Siblings
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Siblings<static>
      */
     public function siblings()
     {
@@ -325,7 +325,7 @@ trait HasAdjacencyList
     /**
      * Get the model's siblings and itself.
      *
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Siblings
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Siblings<static>
      */
     public function siblingsAndSelf()
     {
@@ -346,7 +346,7 @@ trait HasAdjacencyList
      * @param string $foreignKey
      * @param string $localKey
      * @param bool $andSelf
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Siblings
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Siblings<static>
      */
     protected function newSiblings(Builder $query, Model $parent, $foreignKey, $localKey, $andSelf)
     {

--- a/src/Eloquent/Traits/HasGraphAdjacencyList.php
+++ b/src/Eloquent/Traits/HasGraphAdjacencyList.php
@@ -181,7 +181,7 @@ trait HasGraphAdjacencyList
     /**
      * Get the model's ancestors.
      *
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Graph\Ancestors
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Graph\Ancestors<static>
      */
     public function ancestors(): Ancestors
     {
@@ -200,7 +200,7 @@ trait HasGraphAdjacencyList
     /**
      * Get the model's ancestors and itself.
      *
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Graph\Ancestors
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Graph\Ancestors<static>
      */
     public function ancestorsAndSelf(): Ancestors
     {
@@ -227,7 +227,7 @@ trait HasGraphAdjacencyList
      * @param string $parentKey
      * @param string $relatedKey
      * @param bool $andSelf
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Graph\Ancestors
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Graph\Ancestors<static>
      */
     protected function newAncestors(
         Builder $query,
@@ -254,7 +254,7 @@ trait HasGraphAdjacencyList
     /**
      * Get the model's children.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<static>
      */
     public function children(): BelongsToMany
     {
@@ -273,7 +273,7 @@ trait HasGraphAdjacencyList
     /**
      * Get the model's children and itself.
      *
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Graph\Descendants
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Graph\Descendants<static>
      */
     public function childrenAndSelf(): Descendants
     {
@@ -283,7 +283,7 @@ trait HasGraphAdjacencyList
     /**
      * Get the model's descendants.
      *
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Graph\Descendants
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Graph\Descendants<static>
      */
     public function descendants(): Descendants
     {
@@ -302,7 +302,7 @@ trait HasGraphAdjacencyList
     /**
      * Get the model's descendants and itself.
      *
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Graph\Descendants
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Graph\Descendants<static>
      */
     public function descendantsAndSelf(): Descendants
     {
@@ -329,7 +329,7 @@ trait HasGraphAdjacencyList
      * @param string $parentKey
      * @param string $relatedKey
      * @param bool $andSelf
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Graph\Descendants
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Graph\Descendants<static>
      */
     protected function newDescendants(
         Builder $query,
@@ -356,7 +356,7 @@ trait HasGraphAdjacencyList
     /**
      * Get the model's parents.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<static>
      */
     public function parents(): BelongsToMany
     {
@@ -375,7 +375,7 @@ trait HasGraphAdjacencyList
     /**
      * Get the model's parents and itself.
      *
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Graph\Ancestors
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\Graph\Ancestors<static>
      */
     public function parentsAndSelf(): Ancestors
     {

--- a/src/Eloquent/Traits/HasOfDescendantsRelationships.php
+++ b/src/Eloquent/Traits/HasOfDescendantsRelationships.php
@@ -17,7 +17,7 @@ trait HasOfDescendantsRelationships
      * @param string $related
      * @param string|null $foreignKey
      * @param string|null $localKey
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\HasManyOfDescendants
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\HasManyOfDescendants<static>
      */
     public function hasManyOfDescendants($related, $foreignKey = null, $localKey = null)
     {
@@ -42,7 +42,7 @@ trait HasOfDescendantsRelationships
      * @param string $related
      * @param string|null $foreignKey
      * @param string|null $localKey
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\HasManyOfDescendants
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\HasManyOfDescendants<static>
      */
     public function hasManyOfDescendantsAndSelf($related, $foreignKey = null, $localKey = null)
     {
@@ -69,7 +69,7 @@ trait HasOfDescendantsRelationships
      * @param string $foreignKey
      * @param string $localKey
      * @param bool $andSelf
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\HasManyOfDescendants
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\HasManyOfDescendants<static>
      */
     protected function newHasManyOfDescendants(Builder $query, Model $parent, $foreignKey, $localKey, $andSelf)
     {
@@ -85,7 +85,7 @@ trait HasOfDescendantsRelationships
      * @param string|null $relatedPivotKey
      * @param string|null $parentKey
      * @param string|null $relatedKey
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\BelongsToManyOfDescendants
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\BelongsToManyOfDescendants<static>
      */
     public function belongsToManyOfDescendants(
         $related,
@@ -126,7 +126,7 @@ trait HasOfDescendantsRelationships
      * @param string|null $relatedPivotKey
      * @param string|null $parentKey
      * @param string|null $relatedKey
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\BelongsToManyOfDescendants
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\BelongsToManyOfDescendants<static>
      */
     public function belongsToManyOfDescendantsAndSelf(
         $related,
@@ -169,7 +169,7 @@ trait HasOfDescendantsRelationships
      * @param string $parentKey
      * @param string $relatedKey
      * @param bool $andSelf
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\BelongsToManyOfDescendants
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\BelongsToManyOfDescendants<static>
      */
     protected function newBelongsToManyOfDescendants(
         Builder $query,
@@ -204,7 +204,7 @@ trait HasOfDescendantsRelationships
      * @param string|null $parentKey
      * @param string|null $relatedKey
      * @param bool $inverse
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\MorphToManyOfDescendants
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\MorphToManyOfDescendants<static>
      */
     public function morphToManyOfDescendants(
         $related,
@@ -255,7 +255,7 @@ trait HasOfDescendantsRelationships
      * @param string|null $parentKey
      * @param string|null $relatedKey
      * @param bool $inverse
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\MorphToManyOfDescendants
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\MorphToManyOfDescendants<static>
      */
     public function morphToManyOfDescendantsAndSelf(
         $related,
@@ -308,7 +308,7 @@ trait HasOfDescendantsRelationships
      * @param string $relatedKey
      * @param bool $inverse
      * @param bool $andSelf
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\MorphToManyOfDescendants
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\MorphToManyOfDescendants<static>
      */
     protected function newMorphToManyOfDescendants(
         Builder $query,
@@ -346,7 +346,7 @@ trait HasOfDescendantsRelationships
      * @param string|null $relatedPivotKey
      * @param string|null $parentKey
      * @param string|null $relatedKey
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\MorphToManyOfDescendants
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\MorphToManyOfDescendants<static>
      */
     public function morphedByManyOfDescendants(
         $related,
@@ -383,7 +383,7 @@ trait HasOfDescendantsRelationships
      * @param string|null $relatedPivotKey
      * @param string|null $parentKey
      * @param string|null $relatedKey
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\MorphToManyOfDescendants
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\MorphToManyOfDescendants<static>
      */
     public function morphedByManyOfDescendantsAndSelf(
         $related,

--- a/tests/Tree/Models/User.php
+++ b/tests/Tree/Models/User.php
@@ -10,6 +10,9 @@ use Staudenmeir\EloquentHasManyDeep\HasOneDeep;
 use Staudenmeir\EloquentHasManyDeep\HasRelationships;
 use Staudenmeir\EloquentHasManyDeep\HasTableAlias;
 use Staudenmeir\LaravelAdjacencyList\Eloquent\HasRecursiveRelationships;
+use Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\BelongsToManyOfDescendants;
+use Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\HasManyOfDescendants;
+use Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\MorphToManyOfDescendants;
 
 class User extends Model
 {
@@ -20,7 +23,7 @@ class User extends Model
     use HasTableAlias;
     use SoftDeletes;
 
-    public function getCustomPaths()
+    public function getCustomPaths(): array
     {
         return array_merge(
             $this->baseGetCustomPaths(),
@@ -96,42 +99,42 @@ class User extends Model
         );
     }
 
-    public function posts()
+    public function posts(): HasManyOfDescendants
     {
         return $this->hasManyOfDescendants(Post::class);
     }
 
-    public function postsAndSelf()
+    public function postsAndSelf(): HasManyOfDescendants
     {
         return $this->hasManyOfDescendantsAndSelf(Post::class);
     }
 
-    public function roles()
+    public function roles(): BelongsToManyOfDescendants
     {
         return $this->belongsToManyOfDescendants(Role::class);
     }
 
-    public function rolesAndSelf()
+    public function rolesAndSelf(): BelongsToManyOfDescendants
     {
         return $this->belongsToManyOfDescendantsAndSelf(Role::class);
     }
 
-    public function tags()
+    public function tags(): MorphToManyOfDescendants
     {
         return $this->morphToManyOfDescendants(Tag::class, 'taggable');
     }
 
-    public function tagsAndSelf()
+    public function tagsAndSelf(): MorphToManyOfDescendants
     {
         return $this->morphToManyOfDescendantsAndSelf(Tag::class, 'taggable');
     }
 
-    public function videos()
+    public function videos(): MorphToManyOfDescendants
     {
         return $this->morphedByManyOfDescendants(Video::class, 'authorable');
     }
 
-    public function videosAndSelf()
+    public function videosAndSelf(): MorphToManyOfDescendants
     {
         return $this->morphedByManyOfDescendantsAndSelf(Video::class, 'authorable');
     }


### PR DESCRIPTION
Hello!

I've been trying to get the PHPStan level in my codebase up and ran into an issue with this package's relations:
```php
            MaintenanceSystem::find($id)
                ?->descendantsAndSelf()
                ->pluck('id'),
```

produces the following error:
```
Call to private method pluck() of parent class Illuminate\Database\Eloquent\Relations\HasMany<Illuminate\Database\Eloquent\Model>.  
```

The solution is to just make the relations generic and properly extend their parents---note that the generics are currently defined in Larastan's stubs, although they should probably be moved to the framework at some point

Thanks!
