### PR TITLE
Improve relation generics

### DIFF
--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -5,6 +5,11 @@ namespace Staudenmeir\LaravelAdjacencyList\Eloquent;
 use Illuminate\Database\Eloquent\Builder as Base;
 use Staudenmeir\LaravelAdjacencyList\Eloquent\Traits\BuildsAdjacencyListQueries;
 
+/**
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ *
+ * @extends Base<TModel>
+ */
 class Builder extends Base
 {
     use BuildsAdjacencyListQueries;

--- a/src/Eloquent/Relations/RootAncestorOrSelf.php
+++ b/src/Eloquent/Relations/RootAncestorOrSelf.php
@@ -5,6 +5,10 @@ namespace Staudenmeir\LaravelAdjacencyList\Eloquent\Relations;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+ * @extends RootAncestor<TRelatedModel>
+ */
 class RootAncestorOrSelf extends RootAncestor
 {
     /**


### PR DESCRIPTION
Currently `Staudenmeir\LaravelAdjacencyList\Eloquent\Builder` is not generic, while it's parent is. This PR makes it possible to specify which model is passed to the builder.

`RootAncestorOrSelf` is already used as generic in this codebase, but it's not marked as generic. This is also fixed in this PR.

I'm working on bumping the phpstan level to improve coverage in this project, but it are too many changes to include in this PR.