### PR TITLE
#259: Chaperone Tree Relations

### DIFF
--- a/src/Eloquent/Collection.php
+++ b/src/Eloquent/Collection.php
@@ -87,7 +87,9 @@ class Collection extends Base
         $missing = $keys->diff($lookup->modelKeys());
 
         if ($missing->isNotEmpty()) {
-            $lookup->merge($instance->newQuery()->findMany($missing)->keyBy($keyName));
+            $lookup = $lookup->union(
+                $instance->newQuery()->findMany($missing)->keyBy($keyName)
+            );
         }
 
         foreach ($this->all() as $model) {

--- a/src/Eloquent/Collection.php
+++ b/src/Eloquent/Collection.php
@@ -3,6 +3,7 @@
 namespace Staudenmeir\LaravelAdjacencyList\Eloquent;
 
 use Illuminate\Database\Eloquent\Collection as Base;
+use RuntimeException;
 
 /**
  * @template TKey of array-key

--- a/src/Eloquent/Collection.php
+++ b/src/Eloquent/Collection.php
@@ -65,7 +65,7 @@ class Collection extends Base
 
         if (! method_exists($instance, 'getPathName') || ! method_exists($instance, 'getPathSeparator')) {
             throw new RuntimeException(sprintf(
-                'Model [%s] is not have recusive relations.',
+                'Model [%s] does not have recusive relations.',
                 $instance::class,
             ));
         }

--- a/src/Eloquent/Collection.php
+++ b/src/Eloquent/Collection.php
@@ -101,7 +101,7 @@ class Collection extends Base
 
             $model->setRelation('parent', count($path) > 1 ? $lookup[$path[1]] : null);
             $model->setRelation('ancestorsAndSelf', $ancestorsAndSelf);
-            $model->setRelation('ancestors', $ancestorsAndSelf->slice(0, -1));
+            $model->setRelation('ancestors', $ancestorsAndSelf->slice(1));
         }
 
         return $this;

--- a/src/Eloquent/Collection.php
+++ b/src/Eloquent/Collection.php
@@ -67,7 +67,7 @@ class Collection extends Base
 
         if (! method_exists($instance, 'getPathName') || ! method_exists($instance, 'getPathSeparator')) {
             throw new RuntimeException(sprintf(
-                'Model [%s] does not have recusive relations.',
+                'Model [%s] does not have recursive relations.',
                 $instance::class,
             ));
         }

--- a/src/Eloquent/Collection.php
+++ b/src/Eloquent/Collection.php
@@ -57,7 +57,7 @@ class Collection extends Base
      *
      * @return static<int, TModel>
      */
-    public function loadTreePathRelations()
+    public function loadTreePathRelations(): self
     {
         $instance = $this->first();
 

--- a/tests/Tree/CollectionTest.php
+++ b/tests/Tree/CollectionTest.php
@@ -38,4 +38,33 @@ class CollectionTest extends TestCase
 
         $this->assertEmpty($tree);
     }
+
+    public function testLoadTreePathRelations()
+    {
+        $limit = User::count();
+
+        $loaded = 0;
+
+        User::retrieved(function () use (&$count) {
+            $count++;
+        });
+        
+        $tree = User::query()
+            ->tree()
+            ->get()
+            ->loadTreePathRelations()
+            ->each(fn ($s) => $s->setAppends(['slug_path', 'reverse_slug_path']))
+            ->toTree();
+
+        $this->assertLessThanOrEqual($limit, $loaded);
+
+        $this->assertEquals('user-1', $tree[0]->slug_path);
+        $this->assertEquals('user-11', $tree[1]->slug_path);
+        $this->assertEquals('user-1 > user-2', $tree[0]->children[0]->slug_path);
+        $this->assertEquals('user-1 > user-3', $tree[0]->children[1]->slug_path);
+        $this->assertEquals('user-1 > user-4', $tree[0]->children[2]->slug_path);
+        $this->assertEquals('user-1 > user-2 > user-5', $tree[0]->children[0]->children[0]->slug_path);
+        $this->assertEquals('user-1 > user-2 > user-5 > user-8', $tree[0]->children[0]->children[0]->children[0]->slug_path);
+        $this->assertEquals('user-11 > user-12', $tree[1]->children[0]->slug_path);
+    }
 }

--- a/tests/Tree/CollectionTest.php
+++ b/tests/Tree/CollectionTest.php
@@ -53,8 +53,8 @@ class CollectionTest extends TestCase
             $this->assertTrue($user->relationLoaded('ancestorsAndSelf'));
             $this->assertTrue($user->relationLoaded('parent'));
 
-            $this->assertEquals($user->ancestors()->pluck('id')->all(), $user->ancestors->pluck('id')->all());
-            $this->assertEquals($user->ancestorsAndSelf()->pluck('id')->all(), $user->ancestorsAndSelf->pluck('id')->all());
+            $this->assertEquals($user->ancestors()->orderByDesc('depth')->pluck('id')->all(), $user->ancestors->pluck('id')->all());
+            $this->assertEquals($user->ancestorsAndSelf()->orderByDesc('depth')->pluck('id')->all(), $user->ancestorsAndSelf->pluck('id')->all());
             $this->assertEquals($user->parent()->first()?->id, $user->parent?->id);
         }
     }
@@ -72,8 +72,8 @@ class CollectionTest extends TestCase
             $this->assertTrue($user->relationLoaded('ancestorsAndSelf'));
             $this->assertTrue($user->relationLoaded('parent'));
 
-            $this->assertEquals($user->ancestors()->pluck('id')->all(), $user->ancestors->pluck('id')->all());
-            $this->assertEquals($user->ancestorsAndSelf()->pluck('id')->all(), $user->ancestorsAndSelf->pluck('id')->all());
+            $this->assertEquals($user->ancestors()->orderByDesc('depth')->pluck('id')->all(), $user->ancestors->pluck('id')->all());
+            $this->assertEquals($user->ancestorsAndSelf()->orderByDesc('depth')->pluck('id')->all(), $user->ancestorsAndSelf->pluck('id')->all());
             $this->assertEquals($user->parent()->first()?->id, $user->parent?->id);
         }
     }

--- a/tests/Tree/CollectionTest.php
+++ b/tests/Tree/CollectionTest.php
@@ -60,11 +60,11 @@ class CollectionTest extends TestCase
 
         $this->assertEquals('user-1', $tree[0]->display_path);
         $this->assertEquals('user-11', $tree[1]->display_path);
-        $this->assertEquals('user-1 > user-2', $tree[0]->children[0]->display_path);
-        $this->assertEquals('user-1 > user-3', $tree[0]->children[1]->display_path);
-        $this->assertEquals('user-1 > user-4', $tree[0]->children[2]->display_path);
-        $this->assertEquals('user-1 > user-2 > user-5', $tree[0]->children[0]->children[0]->display_path);
-        $this->assertEquals('user-1 > user-2 > user-5 > user-8', $tree[0]->children[0]->children[0]->children[0]->display_path);
+        $this->assertEquals('user-1 > user-2', $tree[0]->children->sortBy('id')[0]->display_path);
+        $this->assertEquals('user-1 > user-3', $tree[0]->children->sortBy('id')[1]->display_path);
+        $this->assertEquals('user-1 > user-4', $tree[0]->children->sortBy('id')[2]->display_path);
+        $this->assertEquals('user-1 > user-2 > user-5', $tree[0]->children->sortBy('id')[0]->children[0]->display_path);
+        $this->assertEquals('user-1 > user-2 > user-5 > user-8', $tree[0]->children->sortBy('id')[0]->children[0]->children[0]->display_path);
         $this->assertEquals('user-11 > user-12', $tree[1]->children[0]->display_path);
     }
 }

--- a/tests/Tree/CollectionTest.php
+++ b/tests/Tree/CollectionTest.php
@@ -54,17 +54,22 @@ class CollectionTest extends TestCase
             ->get()
             ->loadTreePathRelations()
             ->each(fn ($s) => $s->setAppends(['display_path', 'reverse_display_path']))
-            ->toTree();
+	    ->toTree()
+	    ->sortBy('id')
+            ->values();
 
         $this->assertLessThanOrEqual($limit, $loaded);
 
         $this->assertEquals('user-1', $tree[0]->display_path);
-        $this->assertEquals('user-11', $tree[1]->display_path);
-        $this->assertEquals('user-1 > user-2', $tree[0]->children->sortBy('id')[0]->display_path);
-        $this->assertEquals('user-1 > user-3', $tree[0]->children->sortBy('id')[1]->display_path);
-        $this->assertEquals('user-1 > user-4', $tree[0]->children->sortBy('id')[2]->display_path);
-        $this->assertEquals('user-1 > user-2 > user-5', $tree[0]->children->sortBy('id')[0]->children[0]->display_path);
-        $this->assertEquals('user-1 > user-2 > user-5 > user-8', $tree[0]->children->sortBy('id')[0]->children[0]->children[0]->display_path);
+	$this->assertEquals('user-11', $tree[1]->display_path);
+
+	$children = $tree[0]->children->sortBy('id')->values();
+        $this->assertEquals('user-1 > user-2', $children[0]->display_path);
+        $this->assertEquals('user-1 > user-3', $children[1]->display_path);
+	$this->assertEquals('user-1 > user-4', $children[2]->display_path);
+
+        $this->assertEquals('user-1 > user-2 > user-5', $children[0]->children[0]->display_path);
+        $this->assertEquals('user-1 > user-2 > user-5 > user-8', $children[0]->children[0]->children[0]->display_path);
         $this->assertEquals('user-11 > user-12', $tree[1]->children[0]->display_path);
     }
 }

--- a/tests/Tree/CollectionTest.php
+++ b/tests/Tree/CollectionTest.php
@@ -53,18 +53,18 @@ class CollectionTest extends TestCase
             ->tree()
             ->get()
             ->loadTreePathRelations()
-            ->each(fn ($s) => $s->setAppends(['slug_path', 'reverse_slug_path']))
+            ->each(fn ($s) => $s->setAppends(['display_path', 'reverse_display_path']))
             ->toTree();
 
         $this->assertLessThanOrEqual($limit, $loaded);
 
-        $this->assertEquals('user-1', $tree[0]->slug_path);
-        $this->assertEquals('user-11', $tree[1]->slug_path);
-        $this->assertEquals('user-1 > user-2', $tree[0]->children[0]->slug_path);
-        $this->assertEquals('user-1 > user-3', $tree[0]->children[1]->slug_path);
-        $this->assertEquals('user-1 > user-4', $tree[0]->children[2]->slug_path);
-        $this->assertEquals('user-1 > user-2 > user-5', $tree[0]->children[0]->children[0]->slug_path);
-        $this->assertEquals('user-1 > user-2 > user-5 > user-8', $tree[0]->children[0]->children[0]->children[0]->slug_path);
-        $this->assertEquals('user-11 > user-12', $tree[1]->children[0]->slug_path);
+        $this->assertEquals('user-1', $tree[0]->display_path);
+        $this->assertEquals('user-11', $tree[1]->display_path);
+        $this->assertEquals('user-1 > user-2', $tree[0]->children[0]->display_path);
+        $this->assertEquals('user-1 > user-3', $tree[0]->children[1]->display_path);
+        $this->assertEquals('user-1 > user-4', $tree[0]->children[2]->display_path);
+        $this->assertEquals('user-1 > user-2 > user-5', $tree[0]->children[0]->children[0]->display_path);
+        $this->assertEquals('user-1 > user-2 > user-5 > user-8', $tree[0]->children[0]->children[0]->children[0]->display_path);
+        $this->assertEquals('user-11 > user-12', $tree[1]->children[0]->display_path);
     }
 }

--- a/tests/Tree/Models/User.php
+++ b/tests/Tree/Models/User.php
@@ -2,7 +2,6 @@
 
 namespace Staudenmeir\LaravelAdjacencyList\Tests\Tree\Models;
 
-use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Query\Expression;
@@ -154,32 +153,5 @@ class User extends Model
     public function videosAndSelf(): MorphToManyOfDescendants
     {
         return $this->morphedByManyOfDescendantsAndSelf(Video::class, 'authorable');
-    }
-
-    /**
-     * @return Attribute<string,never>
-     */
-    protected function displayPath(): Attribute
-    {
-        return Attribute::get(
-            fn (): string => (string) $this->ancestorsAndSelf
-                ->reverse()
-                ->reduce(function (?string $carry, self $user): ?string {
-                    return $carry ? "{$carry} > {$user->slug}" : $user->slug;
-                }),
-        );
-    }
-
-    /**
-     * @return Attribute<string,never>
-     */
-    protected function reverseDisplayPath(): Attribute
-    {
-        return Attribute::get(
-            fn (): string => (string) $this->ancestorsAndSelf
-                ->reduce(function (?string $carry, self $user): ?string {
-                    return $carry ? "{$carry} < {$user->slug}" : $user->slug;
-                }),
-        );
     }
 }

--- a/tests/Tree/Models/User.php
+++ b/tests/Tree/Models/User.php
@@ -224,7 +224,7 @@ class User extends Model
         return Attribute::get(
             fn (): string => (string) $this->ancestorsAndSelf
                 ->reverse()
-                ->reduce(function ($carry, $user) {
+                ->reduce(function (?string $carry, self $user): ?string {
                     return $carry ? "{$carry} > {$user->slug}" : $user->slug;
                 }),
         );

--- a/tests/Tree/Models/User.php
+++ b/tests/Tree/Models/User.php
@@ -2,6 +2,7 @@
 
 namespace Staudenmeir\LaravelAdjacencyList\Tests\Tree\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Query\Expression;

--- a/tests/Tree/Models/User.php
+++ b/tests/Tree/Models/User.php
@@ -214,4 +214,31 @@ class User extends Model
     {
         return $this->morphedByManyOfDescendantsAndSelf(Video::class, 'authorable');
     }
+
+    /**
+     * @return Attribute<string, never>
+     */
+    protected function displayPath(): Attribute
+    {
+        return Attribute::get(
+            fn (): string => (string) $this->ancestorsAndSelf
+                ->reverse()
+                ->reduce(function ($carry, $item) {
+                    return $carry ? "{$carry} > {$item->name}" : $item->name;
+                }),
+        );
+    }
+
+    /**
+     * @return Attribute<string, never>
+     */
+    protected function displayPathReverse(): Attribute
+    {
+        return Attribute::get(
+            fn (): string => (string) $this->ancestorsAndSelf
+                ->reduce(function ($carry, $item) {
+                    return $carry ? "{$carry} < {$item->name}" : $item->name;
+                }),
+        );
+    }
 }

--- a/tests/Tree/Models/User.php
+++ b/tests/Tree/Models/User.php
@@ -218,7 +218,7 @@ class User extends Model
     /**
      * @return Attribute<string,never>
      */
-    protected function slugPath(): Attribute
+    protected function displayPath(): Attribute
     {
         return Attribute::get(
             fn (): string => (string) $this->ancestorsAndSelf
@@ -232,7 +232,7 @@ class User extends Model
     /**
      * @return Attribute<string,never>
      */
-    protected function reverseSlugPath(): Attribute
+    protected function reverseDisplayPath(): Attribute
     {
         return Attribute::get(
             fn (): string => (string) $this->ancestorsAndSelf

--- a/tests/Tree/Models/User.php
+++ b/tests/Tree/Models/User.php
@@ -216,28 +216,28 @@ class User extends Model
     }
 
     /**
-     * @return Attribute<string, never>
+     * @return Attribute<string,never>
      */
-    protected function displayPath(): Attribute
+    protected function slugPath(): Attribute
     {
         return Attribute::get(
             fn (): string => (string) $this->ancestorsAndSelf
                 ->reverse()
-                ->reduce(function ($carry, $item) {
-                    return $carry ? "{$carry} > {$item->name}" : $item->name;
+                ->reduce(function ($carry, $user) {
+                    return $carry ? "{$carry} > {$user->slug}" : $user->slug;
                 }),
         );
     }
 
     /**
-     * @return Attribute<string, never>
+     * @return Attribute<string,never>
      */
-    protected function displayPathReverse(): Attribute
+    protected function reverseSlugPath(): Attribute
     {
         return Attribute::get(
             fn (): string => (string) $this->ancestorsAndSelf
-                ->reduce(function ($carry, $item) {
-                    return $carry ? "{$carry} < {$item->name}" : $item->name;
+                ->reduce(function ($carry, $user) {
+                    return $carry ? "{$carry} < {$user->slug}" : $user->slug;
                 }),
         );
     }

--- a/tests/Tree/Models/User.php
+++ b/tests/Tree/Models/User.php
@@ -237,7 +237,7 @@ class User extends Model
     {
         return Attribute::get(
             fn (): string => (string) $this->ancestorsAndSelf
-                ->reduce(function ($carry, $user) {
+                ->reduce(function (?string $carry, self $user): ?string {
                     return $carry ? "{$carry} < {$user->slug}" : $user->slug;
                 }),
         );


### PR DESCRIPTION
I was recently working on something where I pulled in a tree, and I needed to access information regarding ancestors of the tree. Tapping into these relations caused database queries, despite the models being within the collection already. This resulted in loading 5x the number of models as I had records in the table.

The solution for something like this would be to manually load in the parent/ancestor relations, so that if these relations are called, they load models already in memory, rather than reaching out to the database again.

I've created a new `loadTreePathRelations()` method, which loads the `parent`, `ancestorsAndSelf`, and `ancestors` relations, which sources as much as possible from the existing collection.