### PR TITLE
MySQL - Including an INT column in Pivot Table Causes invalid SQL Query

### DIFF
--- a/src/Query/Grammars/Traits/CompilesMySqlAdjacencyLists.php
+++ b/src/Query/Grammars/Traits/CompilesMySqlAdjacencyLists.php
@@ -106,7 +106,7 @@ SQL;
         }
 
         $cast = match ($typeName) {
-            'bigint', 'boolean', 'integer', 'smallint', 'tinyint' => 'signed',
+            'bigint', 'boolean', 'integer', 'int', 'smallint', 'tinyint' => 'signed',
             'decimal' => "decimal($precision, $scale)",
             'timestamp' => 'datetime',
             'varchar' => 'char(65535)',

--- a/src/Query/Grammars/Traits/CompilesMySqlAdjacencyLists.php
+++ b/src/Query/Grammars/Traits/CompilesMySqlAdjacencyLists.php
@@ -106,7 +106,7 @@ SQL;
         }
 
         $cast = match ($typeName) {
-            'bigint', 'boolean', 'integer', 'int', 'smallint', 'tinyint' => 'signed',
+            'bigint', 'boolean', 'int', 'smallint', 'tinyint' => 'signed',
             'decimal' => "decimal($precision, $scale)",
             'timestamp' => 'datetime',
             'varchar' => 'char(65535)',


### PR DESCRIPTION
Looks like the type is listed incorrectly as 'integer' for MySQL instead of 'int'. I'm not sure if 'integer' is used in another DB variation so I left it, happy to remove it if needed.

Including an integer column in the 'getPivotColumns' method with Graphs leads an invalid SQL query with MySQL8 and produces - cast(null as int unsigned) as `pivot_my_int_column` 

calling $my_model->descendantsAndSelf()->get() produces an invalid query.