### PR TITLE
add TDeclaringModel to newHasManyOfDescendants

### DIFF
--- a/src/Eloquent/Traits/HasOfDescendantsRelationships.php
+++ b/src/Eloquent/Traits/HasOfDescendantsRelationships.php
@@ -71,13 +71,13 @@ trait HasOfDescendantsRelationships
      * Instantiate a new HasManyOfDescendants relationship.
      *
      * @template TRelatedModel of Model
-     *
+     * @template TDeclaringModel of $this
      * @param \Illuminate\Database\Eloquent\Builder<TRelatedModel> $query
      * @param TRelatedModel $parent
      * @param string $foreignKey
      * @param string $localKey
      * @param bool $andSelf
-     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\HasManyOfDescendants<TRelatedModel>
+     * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\HasManyOfDescendants<TRelatedModel, TDeclaringModel>
      */
     protected function newHasManyOfDescendants(Builder $query, Model $parent, $foreignKey, $localKey, $andSelf)
     {


### PR DESCRIPTION
`HasManyOfDescendants` uses 2 templates but in the trait, we only defined 1 template for it and because of that phpstan2 throws some errors in my codebase. 