### PR TITLE
Adhere to the IDE-helper config

### DIFF
--- a/src/Eloquent/Relations/BelongsToManyOfDescendants.php
+++ b/src/Eloquent/Relations/BelongsToManyOfDescendants.php
@@ -109,7 +109,7 @@ class BelongsToManyOfDescendants extends BelongsToMany
      *
      * @param \Staudenmeir\LaravelAdjacencyList\Eloquent\Builder<TRelatedModel> $query
      * @param \Staudenmeir\LaravelAdjacencyList\Eloquent\Builder<TDeclaringModel> $parentQuery
-     * @param list<string|\Illuminate\Database\Query\Expression>|string|\Illuminate\Database\Query\Expression $columns
+     * @param list<string|\Illuminate\Database\Query\Expression<*>>|string|\Illuminate\Database\Query\Expression<*> $columns
      * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Builder<TRelatedModel>
      */
     public function getRelationExistenceQuery(Builder $query, Builder $parentQuery, $columns = ['*'])

--- a/src/Eloquent/Relations/Descendants.php
+++ b/src/Eloquent/Relations/Descendants.php
@@ -104,7 +104,7 @@ class Descendants extends HasMany implements ConcatenableRelation
      *
      * @param \Illuminate\Database\Eloquent\Builder<TRelatedModel> $query
      * @param \Illuminate\Database\Eloquent\Builder<TDeclaringModel> $parentQuery
-     * @param list<string|\Illuminate\Database\Query\Expression>|string|\Illuminate\Database\Query\Expression $columns
+     * @param list<string|\Illuminate\Database\Query\Expression<*>>|string|\Illuminate\Database\Query\Expression<*> $columns
      * @return \Illuminate\Database\Eloquent\Builder<TRelatedModel>
      */
     public function getRelationExistenceQuery(Builder $query, Builder $parentQuery, $columns = ['*'])

--- a/src/Eloquent/Relations/Graph/Ancestors.php
+++ b/src/Eloquent/Relations/Graph/Ancestors.php
@@ -93,7 +93,7 @@ class Ancestors extends BelongsToMany implements ConcatenableRelation
      *
      * @param \Illuminate\Database\Eloquent\Builder<TRelatedModel> $query
      * @param \Illuminate\Database\Eloquent\Builder<TDeclaringModel> $parentQuery
-     * @param list<string|\Illuminate\Database\Query\Expression>|string|\Illuminate\Database\Query\Expression $columns
+     * @param list<string|\Illuminate\Database\Query\Expression<*>>|string|\Illuminate\Database\Query\Expression<*> $columns
      * @return \Illuminate\Database\Eloquent\Builder<TRelatedModel>
      */
     public function getRelationExistenceQuery(Builder $query, Builder $parentQuery, $columns = ['*'])
@@ -126,7 +126,7 @@ class Ancestors extends BelongsToMany implements ConcatenableRelation
      * Add the constraints for a relationship query on the same table.
      *
      * @param \Illuminate\Database\Eloquent\Builder<TRelatedModel> $query
-     * @param list<string|\Illuminate\Database\Query\Expression>|string|\Illuminate\Database\Query\Expression $columns
+     * @param list<string|\Illuminate\Database\Query\Expression<*>>|string|\Illuminate\Database\Query\Expression<*> $columns
      * @return \Illuminate\Database\Eloquent\Builder<TRelatedModel>
      */
     public function getRelationExistenceQueryForSelfRelation(

--- a/src/Eloquent/Relations/Graph/Descendants.php
+++ b/src/Eloquent/Relations/Graph/Descendants.php
@@ -93,7 +93,7 @@ class Descendants extends BelongsToMany implements ConcatenableRelation
      *
      * @param \Illuminate\Database\Eloquent\Builder<TRelatedModel> $query
      * @param \Illuminate\Database\Eloquent\Builder<TDeclaringModel> $parentQuery
-     * @param list<string|\Illuminate\Database\Query\Expression>|string|\Illuminate\Database\Query\Expression $columns
+     * @param list<string|\Illuminate\Database\Query\Expression<*>>|string|\Illuminate\Database\Query\Expression<*> $columns
      * @return \Illuminate\Database\Eloquent\Builder<TRelatedModel>
      */
     public function getRelationExistenceQuery(Builder $query, Builder $parentQuery, $columns = ['*'])
@@ -126,7 +126,7 @@ class Descendants extends BelongsToMany implements ConcatenableRelation
      * Add the constraints for a relationship query on the same table.
      *
      * @param \Illuminate\Database\Eloquent\Builder<TRelatedModel> $query
-     * @param list<string|\Illuminate\Database\Query\Expression>|string|\Illuminate\Database\Query\Expression $columns
+     * @param list<string|\Illuminate\Database\Query\Expression<*>>|string|\Illuminate\Database\Query\Expression<*> $columns
      * @return \Illuminate\Database\Eloquent\Builder<TRelatedModel>
      */
     public function getRelationExistenceQueryForSelfRelation(

--- a/src/Eloquent/Relations/Graph/Traits/IsRecursiveRelation.php
+++ b/src/Eloquent/Relations/Graph/Traits/IsRecursiveRelation.php
@@ -121,8 +121,8 @@ trait IsRecursiveRelation
      * Replace table hash with expression name in self-relation aggregate queries.
      *
      * @param \Illuminate\Database\Eloquent\Builder<*> $query
-     * @param \Illuminate\Database\Query\Expression $expression
-     * @return \Illuminate\Database\Query\Expression
+     * @param \Illuminate\Database\Query\Expression<*> $expression
+     * @return \Illuminate\Database\Query\Expression<*>
      */
     protected function replaceTableHash(Builder $query, Expression $expression): Expression
     {

--- a/src/Eloquent/Relations/Traits/IsOfDescendantsRelation.php
+++ b/src/Eloquent/Relations/Traits/IsOfDescendantsRelation.php
@@ -380,7 +380,7 @@ trait IsOfDescendantsRelation
      *
      * @param \Staudenmeir\LaravelAdjacencyList\Eloquent\Builder<TRelatedModel> $query
      * @param \Staudenmeir\LaravelAdjacencyList\Eloquent\Builder<TDeclaringModel> $parentQuery
-     * @param list<string|\Illuminate\Database\Query\Expression>|string|\Illuminate\Database\Query\Expression $columns
+     * @param list<string|\Illuminate\Database\Query\Expression<*>>|string|\Illuminate\Database\Query\Expression<*> $columns
      * @return \Staudenmeir\LaravelAdjacencyList\Eloquent\Builder<TRelatedModel>
      */
     public function getRelationExistenceQuery(Builder $query, Builder $parentQuery, $columns = ['*'])

--- a/src/Eloquent/Relations/Traits/IsRecursiveRelation.php
+++ b/src/Eloquent/Relations/Traits/IsRecursiveRelation.php
@@ -92,8 +92,8 @@ trait IsRecursiveRelation
      * Replace table hash with expression name in self-relation aggregate queries.
      *
      * @param \Illuminate\Database\Eloquent\Builder<*> $query
-     * @param \Illuminate\Database\Query\Expression $expression
-     * @return \Illuminate\Database\Query\Expression
+     * @param \Illuminate\Database\Query\Expression<*> $expression
+     * @return \Illuminate\Database\Query\Expression<*>
      */
     protected function replaceTableHash(Builder $query, Expression $expression)
     {

--- a/src/Eloquent/Traits/BuildsAdjacencyListQueries.php
+++ b/src/Eloquent/Traits/BuildsAdjacencyListQueries.php
@@ -19,7 +19,7 @@ trait BuildsAdjacencyListQueries
     /**
      * Get the hydrated models without eager loading.
      *
-     * @param list<string|\Illuminate\Database\Query\Expression>|string $columns
+     * @param list<string|\Illuminate\Database\Query\Expression<*>>|string $columns
      * @return list<\Illuminate\Database\Eloquent\Model>
      */
     public function getModels($columns = ['*'])

--- a/src/IdeHelper/RecursiveRelationsHook.php
+++ b/src/IdeHelper/RecursiveRelationsHook.php
@@ -128,6 +128,7 @@ class RecursiveRelationsHook implements ModelHookInterface
     public function run(ModelsCommand $command, Model $model): void
     {
         $traits = class_uses_recursive($model);
+        // @phpstan-ignore offsetAccess.nonOffsetAccessible same usage as in ide-helper
         $useGenericsSyntax = $command->getLaravel()['config']->get('ide-helper.use_generics_annotations', true);
 
         if (in_array(HasRecursiveRelationships::class, $traits)) {
@@ -167,6 +168,7 @@ class RecursiveRelationsHook implements ModelHookInterface
             !$relationship['manyRelation']
         );
 
+        // @phpstan-ignore offsetAccess.nonOffsetAccessible same usage as in ide-helper
         $addCountProperties = $command->getLaravel()['config']->get('ide-helper.write_model_relation_count_properties', true);
 
         if ($relationship['manyRelation'] && $addCountProperties) {

--- a/src/IdeHelper/RecursiveRelationsHook.php
+++ b/src/IdeHelper/RecursiveRelationsHook.php
@@ -127,9 +127,12 @@ class RecursiveRelationsHook implements ModelHookInterface
 
     public function run(ModelsCommand $command, Model $model): void
     {
+        /** @var \Illuminate\Config\Repository $config */
+        $config = $command->getLaravel()->make('config');
+
         $traits = class_uses_recursive($model);
-        // @phpstan-ignore offsetAccess.nonOffsetAccessible
-        $useGenericsSyntax = $command->getLaravel()['config']->get('ide-helper.use_generics_annotations', true);
+
+        $useGenericsSyntax = $config->get('ide-helper.use_generics_annotations', true);
 
         if (in_array(HasRecursiveRelationships::class, $traits)) {
             foreach (static::$treeRelationships as $relationship) {
@@ -159,6 +162,9 @@ class RecursiveRelationsHook implements ModelHookInterface
      */
     protected function addRelationship(ModelsCommand $command, array $relationship, string $type): void
     {
+        /** @var \Illuminate\Config\Repository $config */
+        $config = $command->getLaravel()->make('config');
+
         $command->setProperty(
             $relationship['name'],
             $type,
@@ -168,8 +174,7 @@ class RecursiveRelationsHook implements ModelHookInterface
             !$relationship['manyRelation']
         );
 
-        // @phpstan-ignore offsetAccess.nonOffsetAccessible
-        $addCountProperties = $command->getLaravel()['config']->get('ide-helper.write_model_relation_count_properties', true);
+        $addCountProperties = $config->get('ide-helper.write_model_relation_count_properties', true);
 
         if ($relationship['manyRelation'] && $addCountProperties) {
             $command->setProperty(

--- a/src/IdeHelper/RecursiveRelationsHook.php
+++ b/src/IdeHelper/RecursiveRelationsHook.php
@@ -127,7 +127,7 @@ class RecursiveRelationsHook implements ModelHookInterface
 
     public function run(ModelsCommand $command, Model $model): void
     {
-        /** @var \Illuminate\Config\Repository $config */
+        /** @var \Illuminate\Contracts\Config\Repository $config */
         $config = $command->getLaravel()->make('config');
 
         $traits = class_uses_recursive($model);
@@ -162,7 +162,7 @@ class RecursiveRelationsHook implements ModelHookInterface
      */
     protected function addRelationship(ModelsCommand $command, array $relationship, string $type): void
     {
-        /** @var \Illuminate\Config\Repository $config */
+        /** @var \Illuminate\Contracts\Config\Repository $config */
         $config = $command->getLaravel()->make('config');
 
         $command->setProperty(

--- a/src/IdeHelper/RecursiveRelationsHook.php
+++ b/src/IdeHelper/RecursiveRelationsHook.php
@@ -128,7 +128,7 @@ class RecursiveRelationsHook implements ModelHookInterface
     public function run(ModelsCommand $command, Model $model): void
     {
         $traits = class_uses_recursive($model);
-        // @phpstan-ignore offsetAccess.nonOffsetAccessible same usage as in ide-helper
+        // @phpstan-ignore offsetAccess.nonOffsetAccessible
         $useGenericsSyntax = $command->getLaravel()['config']->get('ide-helper.use_generics_annotations', true);
 
         if (in_array(HasRecursiveRelationships::class, $traits)) {
@@ -168,7 +168,7 @@ class RecursiveRelationsHook implements ModelHookInterface
             !$relationship['manyRelation']
         );
 
-        // @phpstan-ignore offsetAccess.nonOffsetAccessible same usage as in ide-helper
+        // @phpstan-ignore offsetAccess.nonOffsetAccessible
         $addCountProperties = $command->getLaravel()['config']->get('ide-helper.write_model_relation_count_properties', true);
 
         if ($relationship['manyRelation'] && $addCountProperties) {

--- a/tests/IdeHelper/RecursiveRelationsHookTest.php
+++ b/tests/IdeHelper/RecursiveRelationsHookTest.php
@@ -3,6 +3,8 @@
 namespace Staudenmeir\LaravelAdjacencyList\Tests\IdeHelper;
 
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Contracts\Foundation\Application;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
@@ -16,11 +18,14 @@ class RecursiveRelationsHookTest extends TestCase
 
     public function testTreeRelations(): void
     {
-        $config = Mockery::mock();
+        $config = Mockery::mock(Repository::class);
         $config->shouldReceive('get')->andReturn(true);
 
+        $app = Mockery::mock(Application::class);
+        $app->shouldReceive('make')->andReturn($config);
+
         $command = Mockery::mock(ModelsCommand::class);
-        $command->shouldReceive('getLaravel')->andReturn(['config' => $config]);
+        $command->shouldReceive('getLaravel')->andReturn($app);
         $command->shouldReceive('setProperty')->times(2);
         $command->shouldReceive('setProperty')->once()->with(
             'ancestorsAndSelf',
@@ -55,11 +60,14 @@ class RecursiveRelationsHookTest extends TestCase
 
     public function testGraphRelations(): void
     {
-        $config = Mockery::mock();
+        $config = Mockery::mock(Repository::class);
         $config->shouldReceive('get')->andReturn(true);
 
+        $app = Mockery::mock(Application::class);
+        $app->shouldReceive('make')->andReturn($config);
+
         $command = Mockery::mock(ModelsCommand::class);
-        $command->shouldReceive('getLaravel')->andReturn(['config' => $config]);
+        $command->shouldReceive('getLaravel')->andReturn($app);
         $command->shouldReceive('setProperty')->times(2);
         $command->shouldReceive('setProperty')->once()->with(
             'ancestorsAndSelf',

--- a/tests/IdeHelper/RecursiveRelationsHookTest.php
+++ b/tests/IdeHelper/RecursiveRelationsHookTest.php
@@ -16,11 +16,15 @@ class RecursiveRelationsHookTest extends TestCase
 
     public function testTreeRelations(): void
     {
+        $config = Mockery::mock();
+        $config->shouldReceive('get')->andReturn(true);
+
         $command = Mockery::mock(ModelsCommand::class);
+        $command->shouldReceive('getLaravel')->andReturn(['config' => $config]);
         $command->shouldReceive('setProperty')->times(2);
         $command->shouldReceive('setProperty')->once()->with(
             'ancestorsAndSelf',
-            '\Staudenmeir\LaravelAdjacencyList\Eloquent\Collection|\Staudenmeir\LaravelAdjacencyList\Tests\IdeHelper\Models\User[]',
+            '\Staudenmeir\LaravelAdjacencyList\Eloquent\Collection<int, \Staudenmeir\LaravelAdjacencyList\Tests\IdeHelper\Models\User>',
             true,
             false,
             "The model's recursive parents and itself.",
@@ -51,11 +55,15 @@ class RecursiveRelationsHookTest extends TestCase
 
     public function testGraphRelations(): void
     {
+        $config = Mockery::mock();
+        $config->shouldReceive('get')->andReturn(true);
+
         $command = Mockery::mock(ModelsCommand::class);
+        $command->shouldReceive('getLaravel')->andReturn(['config' => $config]);
         $command->shouldReceive('setProperty')->times(2);
         $command->shouldReceive('setProperty')->once()->with(
             'ancestorsAndSelf',
-            '\Staudenmeir\LaravelAdjacencyList\Eloquent\Graph\Collection|\Staudenmeir\LaravelAdjacencyList\Tests\IdeHelper\Models\Node[]',
+            '\Staudenmeir\LaravelAdjacencyList\Eloquent\Graph\Collection<int, \Staudenmeir\LaravelAdjacencyList\Tests\IdeHelper\Models\Node>',
             true,
             false,
             "The node's recursive parents and itself.",


### PR DESCRIPTION
Hi!

I just started using this package and I noticed that it does not adhere to the ide-helper configuration in my application when it comes to collection generics and relation counts.

```diff
- * @property-read \Staudenmeir\LaravelAdjacencyList\Eloquent\Collection|Location $ancestors The model's recursive parents.
+ * @property-read \Staudenmeir\LaravelAdjacencyList\Eloquent\Collection<int, Location> $ancestors The model's recursive parents.
```

PHPstan gives errors when you use a generic class without specifying what the values are. This change fixes that :)